### PR TITLE
add cvterm rank to output model

### DIFF
--- a/src/main/java/org/genedb/crawl/model/Cvterm.java
+++ b/src/main/java/org/genedb/crawl/model/Cvterm.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 
 public class Cvterm implements Serializable {
-	
+
     public Cvterm() {}
     public Cvterm(String name) {
         this.name = name;
@@ -19,57 +19,58 @@ public class Cvterm implements Serializable {
         this.cv = new Cv();
         this.cv.name = cv;
     }
-	
+
 	public Cv cv;
-	
+
 	@XmlAttribute
 	public String name;
-	
+
 	@XmlAttribute
 	public String accession;
-	
+
 	/**
 	 *  This is not a primitive boolean so it can be nullable (or else the GSON sets it to false if unset).
 	 */
 	@XmlAttribute(name="is_not", required=false)
 	public Boolean is_not;
-	
+
 	@XmlElement(name="dbxref")
 	@XmlElementWrapper(name="dbxrefs", required=false)
 	public List<Dbxref> dbxrefs;
-	
+
 	@XmlElement(name="prop")
 	@XmlElementWrapper(name="props", required=false)
 	public List<CvtermProp> props;
-	
+
 	@XmlElement(name="pub")
 	@XmlElementWrapper(name="pubs", required=false)
 	public List<Pub> pubs;
 
 	@XmlAttribute(required=false)
 	public Integer cvterm_id;
-	
+
 	@XmlAttribute(required=false)
     public Integer count;
-	
+
+    @XmlAttribute(required=false)
+    public Integer rank;
+
 	public void addPub(Pub pub) {
 		if (pubs == null) {
 			pubs = new ArrayList<Pub>();
 		}
 		pubs.add(pub);
 	}
-	
+
 	@XmlAttribute(required=false)
 	public String definition;
-	
+
 	@XmlElement(name="parent")
 	@XmlElementWrapper(name="parents", required=false)
 	public List<CvtermRelationship> parents;
-	
+
 	@XmlElement(name="child")
 	@XmlElementWrapper(name="chilren", required=false)
 	public List<CvtermRelationship> children;
-	
-	
-	
+
 }

--- a/src/main/resources/org/genedb/crawl/mappers/FeatureMapper.xml
+++ b/src/main/resources/org/genedb/crawl/mappers/FeatureMapper.xml
@@ -80,6 +80,7 @@
 		ct.cvterm_id as cvterm_id,
 		c.name as cv,
 		fcp.value as prop,
+		fc.rank as rank,
 		fcpct.name as type_name,
 		fcpc.name as type_cv,
 		NULLIF(pub.uniquename, 'null') as pub_uniqueName,
@@ -119,6 +120,7 @@
 		<id property="accession" column="accession" />
 		<result property="is_not" column="is_not" />
 		<result property="name" column="cvterm" />
+		<result property="rank" column="rank" />
 		<result property="count" column="count" />
 		<association property="cv" javaType="org.genedb.crawl.model.Cv">
 			<result property="name" column="cv" />


### PR DESCRIPTION
This PR adds an additional field to the terms array in the Crawl result, containing the feature_cvterm rank value. Required to identify preferred products in case of multiple product names. 