### PR TITLE
do not consider obsolete features for synonym queries

### DIFF
--- a/src/main/resources/org/genedb/crawl/mappers/FeatureMapper.xml
+++ b/src/main/resources/org/genedb/crawl/mappers/FeatureMapper.xml
@@ -38,11 +38,13 @@
 		<if test="type != null"> and type.name = #{type} </if>
 		WHERE
 			(f.uniquename = #{uniqueName}
-	        OR (f.uniquename IN
-	          (SELECT f.uniquename FROM feature f
-	            JOIN feature_synonym fs ON fs.feature_id = f.feature_id
-	            JOIN synonym s ON s.synonym_id = fs.synonym_id
-	            WHERE s.name = #{uniqueName})))
+		        OR (f.uniquename IN
+		          (SELECT f.uniquename FROM feature f
+		            JOIN feature_synonym fs ON fs.feature_id = f.feature_id
+		            JOIN synonym s ON s.synonym_id = fs.synonym_id
+		            WHERE s.name = #{uniqueName})))
+
+	        AND f.is_obsolete = false
 
 		<if test="organism_id != null">
 			AND f.organism_id = #{organism_id}


### PR DESCRIPTION
Primary IDs of features made obsolete can be re-used as 'previous_systematic_ids'
of non-obsolete features. Including obsolete features in synonym queries will
lead to potentially multiple features being returned from a unique query, which
is not what we want here.

This PR makes sure obsolete features are disregarded in synonym queries, fixing some issues with CRAWL queries, e.g. as currently appearing in http://www.genedb.org/services/feature/hierarchy.json?uniqueName=PKH_000030